### PR TITLE
Add custom handler type

### DIFF
--- a/examples/http_server_with_datasource/main.go
+++ b/examples/http_server_with_datasource/main.go
@@ -36,6 +36,11 @@ func (a *App) getSampleRoutes() []cwhttp.Route {
 			Path:    "/testing",
 			Handler: http.HandlerFunc(a.exampleGet),
 		},
+		{
+			Method:  http.MethodGet,
+			Path:    "/testingCustom",
+			Handler: cwhttp.HandleWithContext(customHandlerType, a.DS),
+		},
 	}
 }
 
@@ -44,6 +49,14 @@ func (a *App) exampleGet(w http.ResponseWriter, r *http.Request) {
 	id := r.URL.Query().Get("id")
 
 	data := a.DS.GetData(id)
+
+	w.Write([]byte(data))
+}
+
+func customHandlerType(w http.ResponseWriter, r *http.Request, ds DataStore) {
+	id := r.URL.Query().Get("id")
+
+	data := ds.GetData(id)
 
 	w.Write([]byte(data))
 }

--- a/examples/http_server_with_datasource/main_test.go
+++ b/examples/http_server_with_datasource/main_test.go
@@ -11,18 +11,22 @@ type MockDS struct {
 	Data string
 }
 
+// GetData satisfies the datastore methods
 func (m MockDS) GetData(id string) string {
 	return m.Data
 }
 
 func TestExampleGet(t *testing.T) {
+	// instantiate the test datastore
 	ds := MockDS{
 		Data: "testing",
 	}
+	// define the app and set the datastore
 	a := App{
 		DS: ds,
 	}
 
+	// set up a test table for our tests
 	tt := []struct {
 		name    string
 		expect  string

--- a/transports/http/router.go
+++ b/transports/http/router.go
@@ -73,6 +73,12 @@ func NewHTTPServer(opts ...ServerOption) *Server {
 	return s
 }
 
+func HandleWithContext[T any](h func(http.ResponseWriter, *http.Request, T), ctx T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		h(w, r, ctx)
+	}
+}
+
 // SetServerPort sets the server listening port
 func SetServerPort(p int) ServerOption {
 	return func(s *Server) {


### PR DESCRIPTION
Adds custom handler type with generics to allow a handler with a custom context object to be passed in.

Use is shown in example