### PR TITLE
Default object errors

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -70,7 +70,7 @@ func (c ClientError) As(target any) bool {
 }
 
 func (c ClientError) WithMetadataErrors(objects ...ErrorWithMetadata) ClientError {
-	c.ErrorsWithMetadata = append(c.ErrorsWithMetadata, objects...)
+	c.ErrorsWithMetadata = objects
 
 	return c
 }
@@ -82,10 +82,17 @@ func WithDetailedError(err error) ClientErrorOpt {
 }
 
 func NewClientError(err error, code int, opts ...ClientErrorOpt) ClientError {
+	metadata := ErrorWithMetadata{
+		Code:    "CWGEN100",
+		Message: err.Error(),
+		Type:    "api",
+		Level:   "warning",
+	}
 	ce := ClientError{
-		Status:        code,
-		Details:       err.Error(),
-		DetailedError: err,
+		Status:             code,
+		Details:            err.Error(),
+		ErrorsWithMetadata: []ErrorWithMetadata{metadata},
+		DetailedError:      err,
 	}
 
 	for _, v := range opts {

--- a/transports/nats/micro.go
+++ b/transports/nats/micro.go
@@ -97,6 +97,7 @@ func GetQueryHeaders(headers micro.Headers, key string) []string {
 	return headers.Values(k)
 }
 
+// handleRequestError will return a client error if it is a client error, otherwise it will return a 500
 func handleRequestError(logger *logr.Logger, err error, r micro.Request) {
 	ce, ok := err.(ClientError)
 	if ok {


### PR DESCRIPTION
This will return a default error with metadata if no metadata errors are passed in to keep consistency across error returns.