### PR TITLE
fix: assign traceShutdown in SetTracerProvider

### DIFF
--- a/transports/http/router.go
+++ b/transports/http/router.go
@@ -151,6 +151,7 @@ func SetIdleTimeout(t int) ServerOption {
 func SetTracerProvider(t *trace.TracerProvider) ServerOption {
 	return func(s *Server) {
 		s.TracerProvider = t
+		s.traceShutdown = t.Shutdown
 	}
 }
 


### PR DESCRIPTION
## Summary

- `SetTracerProvider()` set `s.TracerProvider` but never assigned `s.traceShutdown`
- The nil check at `router.go:202` (`if s.traceShutdown != nil`) always failed
- HTTP handlers were never wrapped with `otelhttp.NewHandler()`, so no spans were created even with a properly configured TracerProvider

One-line fix: `s.traceShutdown = t.Shutdown`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Verified the bug in `go-ratings` — OTel exporter initializes but no spans generated
- [x] After fix, `traceShutdown` is non-nil so handler wrapping activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)